### PR TITLE
add ordering in dimensions for ordered factors

### DIFF
--- a/R/taucharts.R
+++ b/R/taucharts.R
@@ -29,23 +29,27 @@ tauchart <- function(data, width = NULL, height = NULL) {
   # and it should add the ordering of ordered factors
 
   x$dimensions <- lapply(data, function(v) {
+    # if factor handle separately
+    if(inherits(v, "factor")) {
+      if(inherits(v, "ordered")){
+        list(type = "order", order = levels(v) )
+      } else {
+        list(type = "category")
+      }
+    } else {
+      list(`type` =
+             switch(typeof(v),
+                    double={ ifelse(inherits(v, "Date"),
+                                    "order",
+                                    "measure")
+                    },
+                    integer="measure",
+                    logical="category",
+                    character="category",
+                    "measure")
+      )
 
-    list(`type` =
-           switch(typeof(v),
-                  double={ ifelse(inherits(v, "Date"),
-                                  "order",
-                                  "measure")
-                  },
-                  integer={ ifelse(inherits(v, "factor"),
-                                   ifelse(inherits(v, "ordered"),
-                                          "order",
-                                          "category"),
-                                   "measure")
-                  },
-                  logical="category",
-                  character="category",
-                  "measure")
-    )
+    }
 
   })
 


### PR DESCRIPTION
http://api.taucharts.com/datasource/index.html#-ordered-dimension tells us that we can specify a `order` in `dimensions` that should work quite nicely with `ordered factors`.

Example:

``` r
tauchart(scatter_dat) %>% 
  tau_point("cycleTime", "effort", "team", "count")
```

![image](https://cloud.githubusercontent.com/assets/837910/9044741/345e2138-39e4-11e5-937c-0aa1b7c5d121.png)

```
scatter_dat %>%
  {
    data.frame(
      .
      ,cycleTimeFactor = factor(.$cycleTime,levels=rev(unique(.$cycleTime)),ordered=T)
    )
  } %>%
  tauchart %>%
  tau_point("cycleTimeFactor", "effort", "team", "count")
```

![image](https://cloud.githubusercontent.com/assets/837910/9044733/2bf28b9c-39e4-11e5-8292-d0f35e3442bc.png)
