### PR TITLE
add handling for xts objects and crude date conversion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,4 +14,4 @@ Depends: R (>= 3.0.0)
 License: MIT + file LICENSE
 LazyData: true
 Suggests: testthat
-Imports: htmlwidgets, htmltools, magrittr
+Imports: htmlwidgets, htmltools, magrittr, xts

--- a/R/utils.r
+++ b/R/utils.r
@@ -3,3 +3,11 @@ brewers <- c("BrBG", "PiYG", "PRGn", "PuOr", "RdBu", "RdGy", "RdYlBu", "RdYlGn",
 "Set1", "Set2", "Set3", "Blues", "BuGn", "BuPu", "GnBu", "Greens",
 "Greys", "Oranges", "OrRd", "PuBu", "PuBuGn", "PuRd", "Purples",
 "RdPu", "Reds", "YlGn", "YlGnBu", "YlOrBr", "YlOrRd")
+
+
+# from rstudio/dygraphs https://github.com/rstudio/dygraphs
+asISO8601Time <- function(x) {
+  if (!inherits(x, "POSIXct"))
+    x <- as.POSIXct(x, tz = "GMT")
+  format(x, format="%04Y-%m-%dT%H:%M:%SZ", tz='GMT')
+}


### PR DESCRIPTION
This is very much up for discussion.  I borrowed some code from `dygraphs` to convert `Date`/`POSIXct` to ISO8601 format, which `tauCharts` accepts.  In addition, if data is `xts` then it will convert to a `data.frame` with a column `Date` for the `index`.  I have not tested this on all the various complicated date types in `R`, but at least it is a start.

Question:  is a dependency on `xts` ok since this will only be useful for a subset of folks?  We could instead still handle the date conversion but require a `xts` user to convert to an appropriate `data.frame`.

``` r
library(taucharts)
library(quantmod)

spy <- getSymbols("SPY",auto.assign=F)

tauchart( spy ) %>% tau_line( "Date", "SPY.Close" )

# test with as.POSIXct
index(spy) <- as.POSIXct(index(spy))
tauchart(spy) %>% tau_line("Date","SPY.Close") %>% tau_guide_x( tick_format = "%Y")


data.frame(
  date = seq.Date( as.Date("2000-01-01"), as.Date("2000-12-31"), by = "month" )
  ,value = runif(12,0,100)
) %>%
  tauchart() %>%
  tau_point("date","value") %>%
  tau_guide_x( tick_format = "%b %y" )
```
