### PR TITLE
add back trendline on the JavaScript

### DIFF
--- a/R/taucharts.R
+++ b/R/taucharts.R
@@ -23,7 +23,12 @@ tauchart <- function(data, width = NULL, height = NULL) {
 
   # try to handle dates smoothly between JS and R
   #   this is very much a work in progress
-  date_columns <- which(sapply(data,function(x) inherits(x,c("Date","POSIXct"))))
+  date_columns <- which(
+    sapply(
+      data
+      ,function(x) inherits(x,c("Date","POSIXct","yearmon","date","yearqtr"))
+    )
+  )
   data[,date_columns] <- asISO8601Time(data[,date_columns])
   # temporarily set class to iso8601 for dimension logic below
   class(data[,date_columns]) <- "iso8601"

--- a/R/taucharts.R
+++ b/R/taucharts.R
@@ -26,7 +26,6 @@ tauchart <- function(data, width = NULL, height = NULL) {
 
   # try to handle dates smoothly between JS and R
   #   this is very much a work in progress
-<<<<<<< HEAD
   date_columns <- which(
     sapply(
       data
@@ -36,14 +35,6 @@ tauchart <- function(data, width = NULL, height = NULL) {
   data[,date_columns] <- asISO8601Time(data[,date_columns])
   # temporarily set class to iso8601 for dimension logic below
   class(data[,date_columns]) <- "iso8601"
-=======
-  date_columns <- which(sapply(data,function(x) inherits(x,c("Date","POSIXct"))))
-  if (length(date_columns) > 0) {
-    data[,date_columns] <- asISO8601Time(data[,date_columns])
-    # temporarily set class to iso8601 for dimension logic below
-    class(data[,date_columns]) <- "iso8601"
-  }
->>>>>>> 0098d1ebfd5c4a86853f91e93047a5b3d761b1eb
 
   # try to determine the associated tau-type based on
   # column type/class.

--- a/inst/htmlwidgets/taucharts.js
+++ b/inst/htmlwidgets/taucharts.js
@@ -50,6 +50,13 @@ HTMLWidgets.widget({
         if( plugin.type === "legend" ){
           plugins.push(tauCharts.api.plugins.get('legend')());
         }
+
+        if( plugin.type === "trendline" ){
+          if (!Array.isArray(plugin.settings.models)){
+            plugin.settings.models = [plugin.settings.models];
+          }
+          plugins.push(tauCharts.api.plugins.get('trendline')(plugin.settings));
+        }
       })
     }
 


### PR DESCRIPTION
Somehow in yesterday's `git` mania I lost the trendline plugin on the JavaScript side.  This adds it back.
