### PR TITLE
Switch google fonts queries from http to https

### DIFF
--- a/R/fonts.r
+++ b/R/fonts.r
@@ -16,7 +16,7 @@
 #'   tau_set_font("'Montserrat', sans-serif", "http://fonts.googleapis.com/css?family=Montserrat:400,700")
 tau_set_font <- function(tau,
                          family="OpenSans, 'Helvetica Neue', Helvetica, Arial, sans-serif",
-                         import_url="http://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,700,600italic,700italic,800,300,300italic,800italic") {
+                         import_url="https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,600,700,600italic,700italic,800,300,300italic,800italic") {
 
  if (!is.null(import_url)) tau$x$forFonts <- c(tau$x$forFonts, import_url)
 

--- a/R/taucharts.R
+++ b/R/taucharts.R
@@ -79,7 +79,7 @@ tauchart <- function(data, width = NULL, height = NULL) {
     padding=NULL,
     guide=list(x=NULL, y=NULL, padding=NULL, color=NULL),
     forCSS=NULL,
-    forFonts="http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic-ext"
+    forFonts="https://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600&subset=latin,cyrillic-ext"
   )
 
   # create widget


### PR DESCRIPTION
When htmlwidget is hosted on https domain, this becomes mandatory; this should not have any affect on the http case.
