### PR TITLE
add support for returning legend items

### DIFF
--- a/inst/htmlwidgets/taucharts.js
+++ b/inst/htmlwidgets/taucharts.js
@@ -136,22 +136,31 @@ HTMLWidgets.widget({
             Shiny.onInputChange(x.input, e.data)
           })
 
-          // Return the legend label if different from the previous one
-          // if the same or reset button clicked, reset the value to 'null'
-          var clickedLegend = null;
+          // Return the legend label clicked on
+          // If the reset button is clicked, reset the value to 'null'
+          // If the same value is clicked twice, reset to 'null' as well
+          var previousLegend = null;
+
           el.addEventListener('click', function(l) {
-            if (l.target.className == 'tau-chart__legend__guide__label') {
-              if (l.target.innerText !== clickedLegend) {
-                clickedLegend = l.target.innerText;
-              } else {
-                clickedLegend = null;
-              }
-              Shiny.onInputChange(x.input + '-legend', clickedLegend);
+            var updateLegend = false;
+            var className = l.target.classList[0];
+
+            if (className == 'tau-chart__legend__item') {
+              newLegend = l.target.getElementsByClassName("tau-chart__legend__guide__label")[0].innerText;
+              updateLegend = true;
+            }
+            if (className == 'tau-chart__legend__guide__label') {
+              newLegend = l.target.innerText;
+              updateLegend = true;
+            }
+            if (l.target.parentNode.className =='tau-chart__legend__reset ') {
+              newLegend = null;
+              updateLegend = true;
             }
 
-            if (l.target.parentNode.className =='tau-chart__legend__reset ') {
-              clickedLegend = null;
-              Shiny.onInputChange(x.input + '-legend', clickedLegend);
+            if (updateLegend) {
+              previousLegend = newLegend != previousLegend ? newLegend : null;
+              Shiny.onInputChange(x.input + '-legend', previousLegend);
             }
           })
         }

--- a/inst/htmlwidgets/taucharts.js
+++ b/inst/htmlwidgets/taucharts.js
@@ -131,9 +131,30 @@ HTMLWidgets.widget({
         chart.renderTo('#'+el.id);
 
         // Update Shiny inputs, if applicable
-        if (x.input) chart.on('elementclick', function (_, e) {
-          Shiny.onInputChange(x.input, e.data)
-        })
+        if (x.input) {
+          chart.on('elementclick', function (_, e) {
+            Shiny.onInputChange(x.input, e.data)
+          })
+
+          // Return the legend label if different from the previous one
+          // if the same or reset button clicked, reset the value to 'null'
+          var clickedLegend = null;
+          el.addEventListener('click', function(l) {
+            if (l.target.className == 'tau-chart__legend__guide__label') {
+              if (l.target.innerText !== clickedLegend) {
+                clickedLegend = l.target.innerText;
+              } else {
+                clickedLegend = null;
+              }
+              Shiny.onInputChange(x.input + '-legend', clickedLegend);
+            }
+
+            if (l.target.parentNode.className =='tau-chart__legend__reset ') {
+              clickedLegend = null;
+              Shiny.onInputChange(x.input + '-legend', clickedLegend);
+            }
+          })
+        }
 
         // set up a container for tasks to perform after completion
         //  one example would be add callbacks for event handling


### PR DESCRIPTION
Hello,

I added some code so we can retrieve the value of the legend item after a click event. The Shiny input is the input specified in `tauchart()` with `-legend` added at the end (_e.g._ `tauchart(inputId = "test")` yields `input[["test-legend"]]`). 

Please, let me know if you feel this is useful.

Some code to test:

```
library(shiny)
library(taucharts)

ui <- fluidPage(
  titlePanel("Hello Shiny!"),
  sidebarLayout(
    sidebarPanel(),
    mainPanel(
      tauchartsOutput(outputId = "tc"),
      h2("Selected"),
      textOutput(outputId = "leg")
    )
  )
)

server <- function(input, output) {

  output$tc <- renderTaucharts({
    tauchart(iris, inputId = "iris") %>%
      tau_point(x = "Petal.Width", y = "Sepal.Width", color = "Species") %>%
      tau_legend()
  })

  output$leg <- renderText(input[["iris-legend"]])
}

shinyApp(ui = ui, server = server)
```

